### PR TITLE
Feat: Add Taskfile for simpler assignment execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,32 @@
 # COMP 4450 MLOps
 This repo contains all the sub-repos representing each assignment. 
 
+## Prerequisites
+- `uv>=0.7.10`
+  - [uv docs](https://docs.astral.sh/uv/getting-started/installation/)
+- `task>=3.43.3`
+  - [task docs](https://taskfile.dev/installation/)
+
 ## Dependency Management
 The entire monorepo dependency graph is managed by [uv](https://docs.astral.sh/uv/) and uses the [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) feature. This allows __all packages__ within the monorepo to share a single lockfile and a consistent set of dependencies and at the same time, enabling each package to define its own `pyproject.toml`. This greatly simplifies dependency resolution, installation, and script execution for all sub-repos/packages/workspace members. Within each workspace package, I try to add straightforward instructions to execute the individual assignments scripts/apps.
 
+## Execution
+Assignments are ran with [task](https://taskfile.dev/) which is a task runner/build tool that provides a simple and consistent way to execute each assignment's main entry point script.
+
+To run an assignment for a project in its respective `assignments/<project-name>` directory, simply run the following in the CLI:
+```yaml
+task <project-name>
+```
+
 ## Contents 
-All assignments are under `assignments/`:
+All assignments are under `assignments/`
 
 #### Assignment 1: Movie Sentiment ML Pipeline & Streamlit App
 - `movie-sentiment/`
+  - Run command: `task movie-sentiment`
+
+
+
 
 
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+tasks:
+  movie-sentiment:
+    desc: Run the movie sentiment analysis model training and streamlit app
+    dir: assignments/movie-sentiment
+    cmds:
+      - uv run python src/main.py 

--- a/assignments/movie-sentiment/README.md
+++ b/assignments/movie-sentiment/README.md
@@ -22,11 +22,8 @@ movie-sentiment/
 └── uv.lock                         # uv lockfile for deps
 ```
 
-## Installation and Setup
-
-### Prerequisites
-- `uv>=0.7.10`
-  - [uv docs](https://docs.astral.sh/uv/)
+## Manual Installation and Setup 
+- Follow these steps if not using `task` to execute. Refer to the root-level `README.md` for simpler execution instructions.
 
 ### Clone the Repository
 

--- a/assignments/movie-sentiment/src/main.py
+++ b/assignments/movie-sentiment/src/main.py
@@ -1,0 +1,22 @@
+import subprocess
+from src.utils import DATA_PATH, MODEL_PATH, setup_logging
+
+logger = setup_logging()
+
+def main():
+    """Main entry point for the movie sentiment analysis application."""
+    if not MODEL_PATH.exists() and DATA_PATH.exists():
+        logger.info("Training model since model file doesn't exist and IMDB data is present...")
+        subprocess.run(["python", "-m", "src.train.train_model"])
+    elif MODEL_PATH.exists():
+        logger.info("Model file already exists, skipping training...")
+    else:
+        logger.info("Warning: IMDB dataset not found. Please download it to =https://www.kaggle.com/datasets/lakshmi25npathi/imdb-dataset-of-50k-movie-reviews")
+        return
+
+    # Run Streamlit app
+    logger.info("Starting Streamlit app...")
+    subprocess.run(["streamlit", "run", "src/streamlit/app.py"])
+
+if __name__ == "__main__":
+    main()

--- a/assignments/movie-sentiment/src/train/train_model.py
+++ b/assignments/movie-sentiment/src/train/train_model.py
@@ -5,17 +5,18 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.naive_bayes import MultinomialNB
 import joblib
 import os
+from pathlib import Path
 from src.utils import setup_logging, DATA_PATH, MODEL_PATH
 
 logger = setup_logging()
 
 
-def load_and_preprocess_data(data_path: str) -> tuple[np.ndarray, np.ndarray]:
+def load_and_preprocess_data(data_path: Path) -> tuple[np.ndarray, np.ndarray]:
     """
     Load and preprocess the IMDB dataset.
     Returns features (X) and labels (y).
     Args:
-        data_path (str): Path to the IMDB dataset
+        data_path (Path): Path to the IMDB dataset
     Returns:
         X (np.ndarray): Training data / features (X)
         y (np.ndarray): Training Labels / target (y)
@@ -68,13 +69,13 @@ def create_and_train_model(X, y) -> Pipeline:
     
     return pipeline
 
-def save_model(pipeline, model_path) -> None:
+def save_model(pipeline, model_path: Path) -> None:
     """
     Save the trained model pipeline as a pickle file
     to a specified path.
     Args:
         pipeline (Pipeline): Trained pipeline
-        model_path (str): Path to save the model
+        model_path (Path): Path to save the model
     Returns:
         None
     """
@@ -83,8 +84,8 @@ def save_model(pipeline, model_path) -> None:
     joblib.dump(pipeline, model_path)
     
     # Verify the model was saved correctly
-    if os.path.exists(model_path):
-        file_size = os.path.getsize(model_path) / (1024 * 1024)  # MB
+    if model_path.exists():
+        file_size = model_path.stat().st_size / (1024 * 1024)  # MB
         logger.info(f"Model saved successfully! File size: {file_size:.2f} MB")
     else:
         logger.error("Error: Model file was not created!")

--- a/assignments/movie-sentiment/src/utils/__init__.py
+++ b/assignments/movie-sentiment/src/utils/__init__.py
@@ -1,10 +1,11 @@
 import os
 import logging
+from pathlib import Path
 
-# Use os.path.join and make paths relative to project root
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-DATA_PATH = os.path.join(BASE_DIR, 'assets', 'data', 'IMDB Dataset.csv')
-MODEL_PATH = os.path.join(BASE_DIR, 'assets', 'models', 'sentiment_model.pkl')
+# Use pathlib.Path for better path handling
+BASE_DIR = Path(__file__).parent.parent.parent
+DATA_PATH = BASE_DIR / 'assets' / 'data' / 'IMDB Dataset.csv'
+MODEL_PATH = BASE_DIR / 'assets' / 'models' / 'sentiment_model.pkl'
 
 def setup_logging() -> logging.Logger:
     """


### PR DESCRIPTION
# Summary

Added a Taskfile.yml to the root directory to simplify running the movie sentiment analysis application using `uv run`.

# Details
The task automatically:
1. Changes to the correct project directory (`assignments/movie-sentiment`)
2. Uses `uv run` to execute the Python script with proper dependency management
3. Runs the main application which handles model training (if needed) and launches the Streamlit interface

**Usage**: From the root directory, simply run `task movie-sentiment` to start the main script.
