### PR TITLE
Add shell script for uv and task installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ This repo contains all the sub-repos representing each assignment.
 - `task>=3.43.3`
   - [task installation](https://taskfile.dev/installation/)
 
+__Note__: For easy setup on macOS/Linux, use the included installation script:
+```bash
+bash install-tools.sh
+```
+This will install `uv` and `task` if they're not already present and will verify the installation.
+
 ## Dependency Management
 The entire monorepo dependency graph is managed by [uv](https://docs.astral.sh/uv/) and uses the [workspaces](https://docs.astral.sh/uv/concepts/projects/workspaces/) feature. This allows __all packages__ within the monorepo to share a single lockfile and a consistent set of dependencies and at the same time, enabling each package to define its own `pyproject.toml`. This greatly simplifies dependency resolution, installation, and script execution for all sub-repos/packages/workspace members. Within each workspace package, I try to add straightforward instructions to execute the individual assignments scripts/apps.
 
-__NOTE__: To export a `requirements.txt` file that lists out all the dependencies within `assignments/<project-name>`, run the following from the root:
+__Note__: To export a `requirements.txt` file that lists out all the dependencies within `assignments/<project-name>`, run the following from the root:
 ```bash
 uv export --directory assignments/<project-name> -o requirements.txt
 ```

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -8,7 +8,6 @@ NC='\033[0m'
 
 echo -e "${BLUE}🚀 Installing uv and task on macOS...${NC}\n"
 
-# Function to check if command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
@@ -28,14 +27,24 @@ if command_exists uv; then
     uv --version
 else
     echo -e "${BLUE}📦 Installing uv...${NC}"
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    print_status $? "uv installation"
+    # Install uv using Homebrew (recommended for macOS)
+    if command_exists brew; then
+        brew install uv
+        print_status $? "uv installation via Homebrew"
+    else
+        echo -e "${YELLOW}⚠️  Homebrew not found. Installing uv manually...${NC}"
+        # Manual installation as fallback
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        print_status $? "uv installation via script"
+    fi
     
-    # Source the shell configuration to make uv available
-    if [[ "$SHELL" == *"zsh"* ]]; then
-        source ~/.zshrc 2>/dev/null || true
-    elif [[ "$SHELL" == *"bash"* ]]; then
-        source ~/.bashrc 2>/dev/null || true
+    # Source the shell configuration to make uv available (only needed for manual install)
+    if ! command_exists brew; then
+        if [[ "$SHELL" == *"zsh"* ]]; then
+            source ~/.zshrc 2>/dev/null || true
+        elif [[ "$SHELL" == *"bash"* ]]; then
+            source ~/.bashrc 2>/dev/null || true
+        fi
     fi
 fi
 

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' 
+
+echo -e "${BLUE}🚀 Installing uv and task on macOS...${NC}\n"
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+print_status() {
+    if [ $1 -eq 0 ]; then
+        echo -e "${GREEN}✅ $2${NC}"
+    else
+        echo -e "${RED}❌ $2${NC}"
+        return 1
+    fi
+}
+
+# Install uv if not already installed
+if command_exists uv; then
+    echo -e "${YELLOW}⚠️  uv is already installed${NC}"
+    uv --version
+else
+    echo -e "${BLUE}📦 Installing uv...${NC}"
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    print_status $? "uv installation"
+    
+    # Source the shell configuration to make uv available
+    if [[ "$SHELL" == *"zsh"* ]]; then
+        source ~/.zshrc 2>/dev/null || true
+    elif [[ "$SHELL" == *"bash"* ]]; then
+        source ~/.bashrc 2>/dev/null || true
+    fi
+fi
+
+# Install task if not already installed
+if command_exists task; then
+    echo -e "${YELLOW}⚠️  task is already installed${NC}"
+    task --version
+else
+    echo -e "${BLUE}📦 Installing task...${NC}"
+    # Install task using Homebrew (recommended for macOS)
+    if command_exists brew; then
+        brew install go-task
+        print_status $? "task installation via Homebrew"
+    else
+        echo -e "${YELLOW}⚠️  Homebrew not found. Installing task manually...${NC}"
+        # Manual installation as fallback
+        curl -sL https://taskfile.dev/install.sh | sh
+        print_status $? "task installation via script"
+    fi
+fi
+
+echo -e "\n${BLUE}🔍 Verifying installations...${NC}\n"
+
+# Verify uv installation
+if command_exists uv; then
+    echo -e "${GREEN}✅ uv is installed and working:${NC}"
+    uv --version
+else
+    echo -e "${RED}❌ uv installation failed${NC}"
+    exit 1
+fi
+
+# Verify task installation
+if command_exists task; then
+    echo -e "${GREEN}✅ task is installed and working:${NC}"
+    task --version
+else
+    echo -e "${RED}❌ task installation failed${NC}"
+    exit 1
+fi
+
+echo -e "\n${GREEN}🎉 Installation complete! Both uv and task are ready to use.${NC}"
+
+# Show available tasks if Taskfile.yml exists
+if [ -f "Taskfile.yml" ]; then
+    echo -e "\n${BLUE}📋 Available tasks in this project:${NC}"
+    task --list
+fi
+
+echo -e "\n${BLUE}💡 Next steps:${NC}"
+echo -e "  • Run 'task --list' to see available tasks"
+echo -e "  • Run 'task <task-name>' to execute a specific task/assignment" 


### PR DESCRIPTION
# Summary
Execute the following command to get uv and task in the user's environment. 
```bash
bash install-tools.sh
``` 
**Note:** This is for macOS/Linux systems only.

# Details
- Shell script checks if tools are already installed before attempting installation
- Implements multiple paths for uv/task installation:
  - Uses [Homebrew](https://brew.sh/) for installation
    - `brew install go-task` 
    - `brew install uv`
  - Falls back to manual installation if Homebrew isn't available 
    - https://astral.sh/uv/install.sh   
    - https://taskfile.dev/install.sh
- Confirms both tools are properly installed
  - Shows version information for both tools
  - Exits with error if installation fails
- Shows available tasks if `Taskfile.yml` exists
- Provides next steps for running assignments