### PR TITLE
Send stdout logs within Docker to be sent to AWS CloudWatch

### DIFF
--- a/assignments/movie-sentiment-aws/src/streamlit_frontend/Dockerfile
+++ b/assignments/movie-sentiment-aws/src/streamlit_frontend/Dockerfile
@@ -12,9 +12,11 @@ RUN pip install uv
 
 COPY ./src/streamlit_frontend ./src/streamlit_frontend
 COPY ./src/utils ./src/utils
+COPY ./config.yaml ./config.yaml
+COPY ./assets ./assets
 COPY pyproject.toml ./
 
-RUN uv pip install --system --no-cache ".[frontend]"
+RUN uv pip install --system --no-cache -e ".[frontend]"
 
 EXPOSE 8501
 

--- a/assignments/movie-sentiment-aws/src/streamlit_monitoring/app.py
+++ b/assignments/movie-sentiment-aws/src/streamlit_monitoring/app.py
@@ -3,24 +3,35 @@ import streamlit as st
 import pandas as pd
 import altair as alt
 from src.streamlit_monitoring.data_loader import load_feedback_logs, load_imdb_dataset, load_all_logs
+from src.utils import logger
 
 st.set_page_config(page_title="Sentiment Model Monitoring", layout="wide")
+logger.info("Streamlit monitoring app started.")
 
 st.title("Sentiment Model Monitoring Dashboard")
 
 if st.button("🔄 Refresh Data"):
+    logger.info("'Refresh Data' button clicked.")
     st.rerun()
 
 def load_data():
-    all_logs = load_all_logs()
-    feedback_logs = load_feedback_logs()
-    imdb_df = load_imdb_dataset()
-    return all_logs, feedback_logs, imdb_df
+    try:
+        logger.info("Loading all logs, feedback logs, and IMDB dataset.")
+        all_logs = load_all_logs()
+        feedback_logs = load_feedback_logs()
+        imdb_df = load_imdb_dataset()
+        logger.info("Data loading complete.")
+        return all_logs, feedback_logs, imdb_df
+    except Exception as e:
+        logger.exception(f"Failed to load data for monitoring dashboard: {e}")
+        st.error(f"Failed to load data: {e}")
+        return [], [], pd.DataFrame()
 
 all_logs, feedback_logs, imdb_df = load_data()
 
 if not feedback_logs:
     st.warning("No feedback data found. Please add some feedback to see the monitoring dashboard.")
+    logger.warning("No feedback data found for monitoring dashboard.")
 else:
     st.header("Data Drift Analysis")
     
@@ -120,8 +131,11 @@ else:
     
     if accuracy < 0.8:
         st.error("Model accuracy has dropped below 80%!")
+        logger.warning(f"Model accuracy has dropped to {accuracy:.2f}, which is below the 80% threshold.")
+        logger.warning(f"Model precision is {precision:.2f}.")
     else:
         st.success("Model accuracy is above 80%.")
-    
+        logger.info(f"Model accuracy is {accuracy:.2f}, which is above the 80% threshold.")
+        logger.info(f"Model precision is {precision:.2f}.")
     st.header("Raw Feedback Data")
     st.dataframe(pd.DataFrame(feedback_logs))

--- a/assignments/movie-sentiment-aws/terraform/cloudwatch.tf
+++ b/assignments/movie-sentiment-aws/terraform/cloudwatch.tf
@@ -1,0 +1,13 @@
+# Create CloudWatch Log Group
+resource "aws_cloudwatch_log_group" "movie_sentiment" {
+  name              = "/aws/ec2/movie-sentiment-app"
+  retention_in_days = 14
+
+  tags = {
+    Environment = "production"
+    Project     = "Movie-Sentiment-AWS"
+    ManagedBy   = "Terraform"
+  }
+}
+
+


### PR DESCRIPTION
# Summary
This PR implements logging functionality across the ML movie sentiment app. The main change is adding the CloudWatch resource for EC2 instances and monitoring dashboard improvements. This makes it MUCH easier to debug and understand what's going on. Previously, I was SSH'ing into the EC2 instances and manually running commands to get the logs from the specific container instance to debug. That was HORRIBLE.

# Detail
1. CloudWatch Integration
   - Added CloudWatch Log Group resource configuration
   - Updated EC2 instance configurations to enable log streaming from Docker containers to AWS
   - Configured stdout log forwarding from Docker containers to CloudWatch
2. Add logging to Frontend dashboard
3. Add logging to Monitoring dashboard
4. In AWS CLI:

# Screenshots

**Log Groups and Streams**
<img width="1512" height="797" alt="Screenshot 2025-08-04 at 11 03 33 AM" src="https://github.com/user-attachments/assets/3916ea43-4a6e-4a14-af37-a11c6fd5eaf8" />

**Training Logs**
<img width="1511" height="514" alt="Screenshot 2025-08-04 at 11 03 41 AM" src="https://github.com/user-attachments/assets/4ea5d2ca-7fb6-436c-94f2-038ccb624589" />

**Backend Logs**
<img width="1512" height="799" alt="Screenshot 2025-08-04 at 11 03 53 AM" src="https://github.com/user-attachments/assets/ba5cab6b-f750-4979-9cf6-ba810e1540ef" />

**Frontend Logs**
<img width="1512" height="799" alt="Screenshot 2025-08-04 at 11 04 05 AM" src="https://github.com/user-attachments/assets/72da6f7c-a960-4937-98f5-f84107058fde" />




